### PR TITLE
Allow bypassing of the config file

### DIFF
--- a/stream_sim/model.py
+++ b/stream_sim/model.py
@@ -18,8 +18,9 @@ class ConfigurableModel(object):
 
     def __init__(self, config, **kwargs):
         self._config = copy.deepcopy(config)
-        self._config.update(**kwargs)
-        self._create_model()
+        if self._config is not None:
+            self._config.update(**kwargs)
+            self._create_model()
 
     def _create_model(self):
         pass

--- a/stream_sim/observed.py
+++ b/stream_sim/observed.py
@@ -261,7 +261,7 @@ class StreamObserved:
         else:
             raise ValueError(f"Unsupported file format")
 
-    def phi_to_radec(self,phi1,phi2,endpoints = None):
+    def phi_to_radec(self,phi1,phi2,endpoints = None,seed=None):
         """
         Transform coordinates (phi1,phi2) to (ra,dec)
 
@@ -279,7 +279,7 @@ class StreamObserved:
         if endpoints is None:
             # Find two random points in DC2 as endpoints
             print("Generating random endpoints...")
-            np.random.seed(12345)
+            np.random.seed(seed)
             pixels = np.random.choice(pix[hpxmap>0], size=2)
             ra,dec = hp.pix2ang(nside,pixels,lonlat=True)
             self.endpoints = coord.SkyCoord(ra*u.deg, dec*u.deg)

--- a/stream_sim/observed.py
+++ b/stream_sim/observed.py
@@ -308,7 +308,7 @@ class StreamObserved:
         Returns:
             extinction_g, extinction_r: magnitudes extinctions for the given pixels
         """
-        ebv = self.ebv_map[pix].byteswap().newbyteorder()
+        ebv = self.ebv_map[pix].byteswap().view(self.ebv_map.dtype.newbyteorder())
         extinction_g = self.coeff_extinc[0] * ebv
         extinction_r = self.coeff_extinc[1] * ebv
         return extinction_g,extinction_r
@@ -416,7 +416,7 @@ class StreamObserved:
 
     @staticmethod
     def getCompleteness(filename):
-        d = np.recfromcsv(filename)
+        d = np.genfromtxt(filename, delimiter=',', names=True,)
         x = d['mag_r']
 
         selection = 'both'
@@ -457,7 +457,7 @@ class StreamObserved:
         -------
         interp : interpolation function (mag_err as a function of delta_mag)
         """
-        d = np.recfromcsv(filename)
+        d = np.genfromtxt(filename, delimiter=',', names=True,)
 
         x = d['delta_mag']
         y = d['log_mag_err']

--- a/stream_sim/observed.py
+++ b/stream_sim/observed.py
@@ -205,6 +205,10 @@ class StreamObserved:
         # Estimate the extinction, errors
         extinction_g,extinction_r = self.extinction(pix)
 
+        nside_maglim = hp.get_nside(self.maglim_map_r)
+        if nside_maglim != 4096: # adjust the nside to the one of magnitude limit maps
+            pix = hp.ang2pix(nside_maglim, self.stream.icrs.ra.deg, self.stream.icrs.dec.deg, lonlat=True)
+
         magerr_g,magerr_r = self._get_errors(pix,mag_r=data['mag_r']+extinction_r,mag_g=data['mag_g']+extinction_g)
         
         # Sample observed magnitude for every stars
@@ -228,7 +232,7 @@ class StreamObserved:
         # Apply detection threshold
         data['flag_detection_r']=self.detect_flag(pix,mag_r = data['mag_r'],rng=rng,seed=seed,**kwargs)
         data['flag_detection_g']=self.detect_flag(pix,mag_g = data['mag_g'],rng=rng,seed=seed,**kwargs)
-        data['flag_detection'] = (data['flag_detection_r']==1)&(data['flag_detection_g']==1)
+        data['flag_detection'] = (data['flag_detection_r']==1)|(data['flag_detection_g']==1)
 
         if kwargs.get('save'):
             self._save_injected_data(data, kwargs.get('folder', None))


### PR DESCRIPTION
This allows to create a model object, and use its functions
```python
stream = StreamModel(config)
dist = stream.distance_modulus.sample(phi1)
mag_g, mag_r = stream.isochrone.sample(len(phi1),dist)
```
even though the config doesn't contain information about density or track, for example.

I changed this because I wanted to be able to skip some generation steps, to sample magnitudes and distances for a simulation with existing phi1 phi2. 

I also did some minor changes:
- removing np.random to use np.random_Generator instead, and optional seed
- Adapt code for numy>2
- allow different nside for magnitude limit maps
- noted as 'BAD_MAG' the negative fluxes, instead of 99.
- Add an option to force the injection of stream to be inside the magnitude limit map in r and g bands