### PR TITLE
Injection modifications

### DIFF
--- a/stream_sim/observed.py
+++ b/stream_sim/observed.py
@@ -476,7 +476,7 @@ class StreamObserved:
             """ Take the saturation into account by using the error value in the bright end """
             magerr = 10 ** (np.where(((mag - maglim)<=-10)&(mag>=self.saturation), self.log_photo_error(-10), self.log_photo_error(mag - maglim)))
             magerr = np.where(mag<self.saturation, 10 ** self.log_photo_error(-11), magerr) # saturation at the bright end
-            mag_err += self.sys_error # add systematic error
+            magerr += self.sys_error # add systematic error
             return magerr
 
         # Magnitude errors

--- a/stream_sim/observed.py
+++ b/stream_sim/observed.py
@@ -188,7 +188,9 @@ class StreamObserved:
             self.saturation = self._config["survey_properties"]["saturation"]
         except KeyError as e:
             self.saturation = 16.0
-            print(f"Missing key {e} in the survey_properties config. Using default saturation={self.saturation}.")
+            print(
+                f"Missing key {e} in the survey_properties config. Using default saturation={self.saturation}."
+            )
 
     def inject(self, data, **kwargs):
         """
@@ -478,10 +480,18 @@ class StreamObserved:
         return magerr_g, magerr_r
 
     def _effective_errors(self, mag, maglim):
-        """ Take the saturation into account by using the error value in the bright end """
-        magerr = 10 ** (np.where(((mag - maglim)<=-10)&(mag>=self.saturation), self.log_photo_error(-10), self.log_photo_error(mag - maglim)))
-        magerr = np.where(mag<self.saturation, 10 ** self.log_photo_error(-11), magerr) # saturation at the bright end
-        magerr += self.sys_error # add systematic error
+        """Take the saturation into account by using the error value in the bright end"""
+        magerr = 10 ** (
+            np.where(
+                ((mag - maglim) <= -10) & (mag >= self.saturation),
+                self.log_photo_error(-10),
+                self.log_photo_error(mag - maglim),
+            )
+        )
+        magerr = np.where(
+            mag < self.saturation, 10 ** self.log_photo_error(-11), magerr
+        )  # saturation at the bright end
+        magerr += self.sys_error  # add systematic error
         return magerr
 
     def sample(self, **kwargs):
@@ -577,13 +587,27 @@ class StreamObserved:
 
         return threshold
 
-    def _effective_completeness(self, mag, maglim_map, maglim0, saturation0, clipping_bounds):
-        delta_mag = mag -  np.clip(maglim_map, clipping_bounds[0], clipping_bounds[1]) # difference between the mag and the maglim at the position of the object
-        eq_mag = delta_mag + maglim0 # convert the delta mag to the equivalent mag at maglim0
+    def _effective_completeness(
+        self, mag, maglim_map, maglim0, saturation0, clipping_bounds
+    ):
+        delta_mag = mag - np.clip(
+            maglim_map, clipping_bounds[0], clipping_bounds[1]
+        )  # difference between the mag and the maglim at the position of the object
+        eq_mag = (
+            delta_mag + maglim0
+        )  # convert the delta mag to the equivalent mag at maglim0
         # Apply saturation condition: 1 padding for objects fainter than saturation but equivalent mag brighter than saturation0
-        compl = np.where((mag > self.saturation)&(eq_mag < saturation0), 1.0, self.completeness(eq_mag)) # 1 padded
-        compl = np.where(mag < self.saturation, 0.0, compl) # saturation at the bright end
-        compl = np.where((maglim_map < self.saturation)|np.isnan(maglim_map), 0.0, compl) # not observed if the area is not covered
+        compl = np.where(
+            (mag > self.saturation) & (eq_mag < saturation0),
+            1.0,
+            self.completeness(eq_mag),
+        )  # 1 padded
+        compl = np.where(
+            mag < self.saturation, 0.0, compl
+        )  # saturation at the bright end
+        compl = np.where(
+            (maglim_map < self.saturation) | np.isnan(maglim_map), 0.0, compl
+        )  # not observed if the area is not covered
         return compl
 
     def _save_injected_data(self, data, folder):

--- a/stream_sim/observed.py
+++ b/stream_sim/observed.py
@@ -472,17 +472,17 @@ class StreamObserved:
         maglim_g = self.maglim_map_g[pix]
         maglim_r = self.maglim_map_r[pix]
 
-        def effective_error(mag,maglim):
-            """ Take the saturation into account by using the error value in the bright end """
-            magerr = 10 ** (np.where(((mag - maglim)<=-10)&(mag>=self.saturation), self.log_photo_error(-10), self.log_photo_error(mag - maglim)))
-            magerr = np.where(mag<self.saturation, 10 ** self.log_photo_error(-11), magerr) # saturation at the bright end
-            magerr += self.sys_error # add systematic error
-            return magerr
-
         # Magnitude errors
-        magerr_g = effective_error(mag_g, maglim_g)
-        magerr_r = effective_error(mag_r, maglim_r)
+        magerr_g = self._effective_errors(mag_g, maglim_g)
+        magerr_r = self._effective_errors(mag_r, maglim_r)
         return magerr_g, magerr_r
+
+    def _effective_errors(self, mag, maglim):
+        """ Take the saturation into account by using the error value in the bright end """
+        magerr = 10 ** (np.where(((mag - maglim)<=-10)&(mag>=self.saturation), self.log_photo_error(-10), self.log_photo_error(mag - maglim)))
+        magerr = np.where(mag<self.saturation, 10 ** self.log_photo_error(-11), magerr) # saturation at the bright end
+        magerr += self.sys_error # add systematic error
+        return magerr
 
     def sample(self, **kwargs):
         """

--- a/stream_sim/observed.py
+++ b/stream_sim/observed.py
@@ -235,6 +235,14 @@ class StreamObserved:
         )
 
         # Estimate the extinction, errors
+        nside_ebv = hp.get_nside(self.ebv_map)
+        if nside_ebv != 4096:  # adjust the nside to the one of extinction map
+            pix = hp.ang2pix(
+                nside_ebv,
+                self.stream.icrs.ra.deg,
+                self.stream.icrs.dec.deg,
+                lonlat=True,
+            )
         extinction_g, extinction_r = self.extinction(pix)
 
         nside_maglim = hp.get_nside(self.maglim_map_r)

--- a/stream_sim/observed.py
+++ b/stream_sim/observed.py
@@ -474,8 +474,9 @@ class StreamObserved:
 
         def effective_error(mag,maglim):
             """ Take the saturation into account by using the error value in the bright end """
-            magerr =self.sys_error + 10 ** (np.where(((mag - maglim)<=-10)&(mag>=self.saturation), self.log_photo_error(-10), self.log_photo_error(mag - maglim)))
-            magerr =  np.where(mag<self.saturation, 10 ** self.log_photo_error(-11), magerr) # saturation at the bright end
+            magerr = 10 ** (np.where(((mag - maglim)<=-10)&(mag>=self.saturation), self.log_photo_error(-10), self.log_photo_error(mag - maglim)))
+            magerr = np.where(mag<self.saturation, 10 ** self.log_photo_error(-11), magerr) # saturation at the bright end
+            mag_err += self.sys_error # add systematic error
             return magerr
 
         # Magnitude errors

--- a/stream_sim/observed.py
+++ b/stream_sim/observed.py
@@ -579,7 +579,7 @@ class StreamObserved:
             maglim_map = self.maglim_map_g[pix]
 
         compl = self._effective_completeness(
-            mag, maglim_map, maglim0, self.saturation, saturation0, clipping_bounds
+            mag, maglim_map, maglim0, saturation0, clipping_bounds
         )
 
         # Set the threshold using completeness 1-padded at the bright ends

--- a/stream_sim/observed.py
+++ b/stream_sim/observed.py
@@ -475,6 +475,7 @@ class StreamObserved:
         def effective_error(mag,maglim):
             """ Take the saturation into account by using the error value in the bright end """
             magerr =self.sys_error + 10 ** (np.where(((mag - maglim)<=-10)&(mag>=self.saturation), self.log_photo_error(-10), self.log_photo_error(mag - maglim)))
+            magerr =  np.where(mag<self.saturation, 10 ** self.log_photo_error(-11), magerr) # saturation at the bright end
             return magerr
 
         # Magnitude errors
@@ -572,7 +573,7 @@ class StreamObserved:
             # Apply saturation condition: 1 padding for objects brighter than saturation but equivalent mag fainter than saturation0
             compl = np.where((mag > self.saturation)&(eq_mag < saturation0), 1.0, self.completeness(eq_mag)) # 1 padded
             compl = np.where(mag < self.saturation, 0.0, compl) # saturation at the bright end
-            compl = np.where(maglim_map < self.saturation, 0.0, compl) # not observed if the area is not covered
+            compl = np.where((maglim_map < self.saturation)|np.isnan(maglim_map), 0.0, compl) # not observed if the area is not covered
             return compl
 
         # Set the threshold using completeness 1-padded at the bright ends

--- a/stream_sim/observed.py
+++ b/stream_sim/observed.py
@@ -243,6 +243,7 @@ class StreamObserved:
                 self.stream.icrs.dec.deg,
                 lonlat=True,
             )
+
         extinction_g, extinction_r = self.extinction(pix)
 
         nside_maglim = hp.get_nside(self.maglim_map_r)
@@ -290,11 +291,11 @@ class StreamObserved:
             mag_r_meas != "BAD_MAG"
         )  # Negative fluxes are set to 'BAD_MAG', so counted as undetected
         data["flag_detection_r"] = flag_r & self.detect_flag(
-            pix, mag_r=data["mag_r"], rng=rng, seed=seed, **kwargs
+            pix, mag_r=data["mag_r"] + extinction_r, rng=rng, seed=seed, **kwargs
         )
         flag_g = mag_g_meas != "BAD_MAG"
         data["flag_detection_g"] = flag_g & self.detect_flag(
-            pix, mag_g=data["mag_g"], rng=rng, seed=seed, **kwargs
+            pix, mag_g=data["mag_g"] + extinction_g, rng=rng, seed=seed, **kwargs
         )
 
         data["flag_detection"] = (data["flag_detection_r"] == 1) & (

--- a/stream_sim/observed.py
+++ b/stream_sim/observed.py
@@ -537,7 +537,7 @@ class StreamObserved:
         """
         # Default parameters
         maglim0 = kwargs.pop(
-            "maglim0", 25.0
+            "maglim0", 26.8
         )  # magnitude limit in the initial completeness
         saturation0 = kwargs.pop(
             "saturation0", 16.4
@@ -565,7 +565,7 @@ class StreamObserved:
             maglim_map = self.maglim_map_g[pix]
 
         def effective_completeness(mag):
-            delta_mag = mag -  np.clip(maglim_map, 20, 30) # difference between the mag and the maglim at the position of the object
+            delta_mag = mag -  np.clip(maglim_map, clipping_bounds[0], clipping_bounds[1]) # difference between the mag and the maglim at the position of the object
             eq_mag = delta_mag + maglim0 # convert the delta mag to the equivalent mag at maglim0
             # Apply saturation condition: 1 padding for objects brighter than saturation but equivalent mag fainter than saturation0
             compl = np.where((mag > saturation)&(eq_mag < saturation0), 1.0, self.completeness(eq_mag)) # 1 padded
@@ -575,7 +575,7 @@ class StreamObserved:
 
         # Set the threshold using completeness 1-padded at the bright ends
         threshold = rng.uniform(size=len(mag)) <= effective_completeness(mag)
-        
+
         return threshold
 
     def _save_injected_data(self, data, folder):


### PR DESCRIPTION
Important corrections in the injection part.

### Saturation of the errors
- Before: errors saturation was not aligned with the survey saturation level.
- In this pull request: adding padding if necessary, and shifted saturation.

Example:
For deeper survey: padding down to the saturation
<img width="857" height="468" alt="image" src="https://github.com/user-attachments/assets/986765a1-79b9-441d-8cb1-cbd870b1dd21" />

For less deep survey: saturation shifted
<img width="857" height="468" alt="image" src="https://github.com/user-attachments/assets/fb11531b-528f-471c-8855-c23ab21decfd" />

### Completeness
Before: No impact of dust extinction
In this pull request: takes the apparent magnitude (true magnitude + dust extinction) as input. 

Changed the magnitude limit of the map used to estimate the initial completeness (maglim0), from 25 to 26.8, according to [Kabelo Tsiane 2025](https://arxiv.org/pdf/2504.16203).

For better readability, I also wrote it as an effective completeness that includes:
- shift of the completeness function obtained from DC2
- 1 padding for deeper survey than DC2
- saturation of the survey
- survey's coverage


### Other small adjustments
- Since the survey magnitude saturation limit is needed in different functions (errors, completeness), and as it is an intrinsic characteristic of the experiment, it is now stored as an attributed, that can be modified in the survey config file.
- Avoid some errors in the pixel assignment for the dust extinction map
