### PR TITLE
Star galaxie separation, dust, and minor improvements

### DIFF
--- a/bin/download_data.py
+++ b/bin/download_data.py
@@ -21,7 +21,7 @@ import tempfile
 # =============================================================================
 
 # Base URL where data archive is hosted
-BASE_DATA_URL = "https://zenodo.org/records/17589908/files/"
+BASE_DATA_URL = "https://zenodo.org/records/17939098/files/"
 
 # Name of the data archive file (should be a zip file)
 DATA_ARCHIVE_NAME = "data.zip"

--- a/config/surveys/lsst_dc2.yaml
+++ b/config/surveys/lsst_dc2.yaml
@@ -11,8 +11,8 @@ survey_files:
 
     # Band-independent maps
     ebv_map: ebv_sfd98_lowres_nside_512_ring_equatorial.fits
-    completeness: stellar_efficiency_cutr.csv
-    log_photo_error: photoerror_r.csv
+    completeness: lsst_stellar_efficiency_cutr.csv
+    log_photo_error: lsst_photoerror_r.csv
     #coverage: supreme_dc2_dr6d_v3_gr_fracdet.fits.gz # Optional coverage map, if not provided, coverage is built using maglim maps
 
 survey_properties: 

--- a/config/surveys/lsst_dc2.yaml
+++ b/config/surveys/lsst_dc2.yaml
@@ -19,13 +19,16 @@ survey_properties:
   bands: ['u', 'g', 'r', 'i', 'z', 'y']
 
   # Extinction coefficients per band (A_band / E(B-V)) 
-  # from Tab 6 of https://iopscience.iop.org/article/10.1088/0004-637X/737/2/103/pdf
-  coeff_extinc_u: 4.145
-  coeff_extinc_g: 3.237
-  coeff_extinc_r: 2.273
-  coeff_extinc_i: 1.684 
-  coeff_extinc_z: 1.323 
-  coeff_extinc_y: 1.088
+  # From rubin_sim (verions = 2.6.0, baseline version = 5.0.0)
+  # from rubin_sim.phot_utils import DustValues
+  # dust_values = DustValues()
+  # print(dust_values.r_x)
+  coeff_extinc_u: 4.757217815396922
+  coeff_extinc_g: 3.6605664439892625
+  coeff_extinc_r: 2.70136780871597
+  coeff_extinc_i: 2.0536599130965882
+  coeff_extinc_z: 1.5900964472616756
+  coeff_extinc_y: 1.3077049588254708
 
   # Systematic photometric errors (mag), or could be specified as sys_error_g, sys_error_r, etc
   sys_error : 0.005 # Error common to all bands

--- a/config/surveys/lsst_yr1.yaml
+++ b/config/surveys/lsst_yr1.yaml
@@ -11,8 +11,8 @@ survey_files:
 
     # Band-independent maps
     ebv_map: ebv_sfd98_lowres_nside_512_ring_equatorial.fits
-    completeness: stellar_efficiency_cutr.csv
-    log_photo_error: photoerror_r.csv
+    completeness: lsst_stellar_efficiency_cutr.csv
+    log_photo_error: lsst_photoerror_r.csv
 
 survey_properties: 
   bands: ['u', 'g', 'r', 'i', 'z', 'y']

--- a/config/surveys/lsst_yr1.yaml
+++ b/config/surveys/lsst_yr1.yaml
@@ -18,13 +18,16 @@ survey_properties:
   bands: ['u', 'g', 'r', 'i', 'z', 'y']
 
   # Extinction coefficients per band (A_band / E(B-V)) 
-  # from Tab 6 of https://iopscience.iop.org/article/10.1088/0004-637X/737/2/103/pdf
-  coeff_extinc_u: 4.145
-  coeff_extinc_g: 3.237
-  coeff_extinc_r: 2.273
-  coeff_extinc_i: 1.684 
-  coeff_extinc_z: 1.323 
-  coeff_extinc_y: 1.088
+  # From rubin_sim (verions = 2.6.0, baseline version = 5.0.0)
+  # from rubin_sim.phot_utils import DustValues
+  # dust_values = DustValues()
+  # print(dust_values.r_x)
+  coeff_extinc_u: 4.757217815396922
+  coeff_extinc_g: 3.6605664439892625
+  coeff_extinc_r: 2.70136780871597
+  coeff_extinc_i: 2.0536599130965882
+  coeff_extinc_z: 1.5900964472616756
+  coeff_extinc_y: 1.3077049588254708
 
   # Systematic photometric errors (mag), or could be specified as sys_error_g, sys_error_r, etc
   sys_error : 0.005 # Error common to all bands

--- a/config/surveys/lsst_yr2.yaml
+++ b/config/surveys/lsst_yr2.yaml
@@ -11,8 +11,8 @@ survey_files:
 
     # Band-independent maps
     ebv_map: ebv_sfd98_lowres_nside_512_ring_equatorial.fits
-    completeness: stellar_efficiency_cutr.csv
-    log_photo_error: photoerror_r.csv
+    completeness: lsst_stellar_efficiency_cutr.csv
+    log_photo_error: lsst_photoerror_r.csv
 
 survey_properties: 
   bands: ['u', 'g', 'r', 'i', 'z', 'y']

--- a/config/surveys/lsst_yr2.yaml
+++ b/config/surveys/lsst_yr2.yaml
@@ -18,13 +18,16 @@ survey_properties:
   bands: ['u', 'g', 'r', 'i', 'z', 'y']
 
   # Extinction coefficients per band (A_band / E(B-V)) 
-  # from Tab 6 of https://iopscience.iop.org/article/10.1088/0004-637X/737/2/103/pdf
-  coeff_extinc_u: 4.145
-  coeff_extinc_g: 3.237
-  coeff_extinc_r: 2.273
-  coeff_extinc_i: 1.684 
-  coeff_extinc_z: 1.323 
-  coeff_extinc_y: 1.088
+  # From rubin_sim (verions = 2.6.0, baseline version = 5.0.0)
+  # from rubin_sim.phot_utils import DustValues
+  # dust_values = DustValues()
+  # print(dust_values.r_x)
+  coeff_extinc_u: 4.757217815396922
+  coeff_extinc_g: 3.6605664439892625
+  coeff_extinc_r: 2.70136780871597
+  coeff_extinc_i: 2.0536599130965882
+  coeff_extinc_z: 1.5900964472616756
+  coeff_extinc_y: 1.3077049588254708
 
   # Systematic photometric errors (mag), or could be specified as sys_error_g, sys_error_r, etc
   sys_error : 0.005 # Error common to all bands

--- a/config/surveys/lsst_yr2.yaml
+++ b/config/surveys/lsst_yr2.yaml
@@ -1,0 +1,36 @@
+# Configuration file for the survey LSST
+name: lsst
+release: yr2
+survey_files: 
+    # Path to data files (leave empty for default location)
+    file_path: ''
+
+    # Band-specific magnitude limit maps
+    maglim_map_g: baseline_v5.0.0_year_2.0_band_g_nside_128.hsp
+    maglim_map_r: baseline_v5.0.0_year_2.0_band_r_nside_128.hsp
+
+    # Band-independent maps
+    ebv_map: ebv_sfd98_lowres_nside_512_ring_equatorial.fits
+    completeness: stellar_efficiency_cutr.csv
+    log_photo_error: photoerror_r.csv
+
+survey_properties: 
+  bands: ['u', 'g', 'r', 'i', 'z', 'y']
+
+  # Extinction coefficients per band (A_band / E(B-V)) 
+  # from Tab 6 of https://iopscience.iop.org/article/10.1088/0004-637X/737/2/103/pdf
+  coeff_extinc_u: 4.145
+  coeff_extinc_g: 3.237
+  coeff_extinc_r: 2.273
+  coeff_extinc_i: 1.684 
+  coeff_extinc_z: 1.323 
+  coeff_extinc_y: 1.088
+
+  # Systematic photometric errors (mag), or could be specified as sys_error_g, sys_error_r, etc
+  sys_error : 0.005 # Error common to all bands
+  # sys_error_i: 0.01  # Example to Override for i-band
+
+
+  # Saturation limits per band, or could be specified as saturation_g, saturation_r, etc
+  saturation: 16.0
+  #saturation_u: 15.0  # Override for u-band

--- a/config/surveys/lsst_yr3.yaml
+++ b/config/surveys/lsst_yr3.yaml
@@ -11,8 +11,8 @@ survey_files:
 
     # Band-independent maps
     ebv_map: ebv_sfd98_lowres_nside_512_ring_equatorial.fits
-    completeness: stellar_efficiency_cutr.csv
-    log_photo_error: photoerror_r.csv
+    completeness: lsst_stellar_efficiency_cutr.csv
+    log_photo_error: lsst_photoerror_r.csv
 
 survey_properties: 
   bands: ['u', 'g', 'r', 'i', 'z', 'y']

--- a/config/surveys/lsst_yr3.yaml
+++ b/config/surveys/lsst_yr3.yaml
@@ -1,0 +1,36 @@
+# Configuration file for the survey LSST
+name: lsst
+release: yr3
+survey_files: 
+    # Path to data files (leave empty for default location)
+    file_path: ''
+
+    # Band-specific magnitude limit maps
+    maglim_map_g: baseline_v5.0.0_year_3.0_band_g_nside_128.hsp
+    maglim_map_r: baseline_v5.0.0_year_3.0_band_r_nside_128.hsp
+
+    # Band-independent maps
+    ebv_map: ebv_sfd98_lowres_nside_512_ring_equatorial.fits
+    completeness: stellar_efficiency_cutr.csv
+    log_photo_error: photoerror_r.csv
+
+survey_properties: 
+  bands: ['u', 'g', 'r', 'i', 'z', 'y']
+
+  # Extinction coefficients per band (A_band / E(B-V)) 
+  # from Tab 6 of https://iopscience.iop.org/article/10.1088/0004-637X/737/2/103/pdf
+  coeff_extinc_u: 4.145
+  coeff_extinc_g: 3.237
+  coeff_extinc_r: 2.273
+  coeff_extinc_i: 1.684 
+  coeff_extinc_z: 1.323 
+  coeff_extinc_y: 1.088
+
+  # Systematic photometric errors (mag), or could be specified as sys_error_g, sys_error_r, etc
+  sys_error : 0.005 # Error common to all bands
+  # sys_error_i: 0.01  # Example to Override for i-band
+
+
+  # Saturation limits per band, or could be specified as saturation_g, saturation_r, etc
+  saturation: 16.0
+  #saturation_u: 15.0  # Override for u-band

--- a/config/surveys/lsst_yr3.yaml
+++ b/config/surveys/lsst_yr3.yaml
@@ -18,13 +18,16 @@ survey_properties:
   bands: ['u', 'g', 'r', 'i', 'z', 'y']
 
   # Extinction coefficients per band (A_band / E(B-V)) 
-  # from Tab 6 of https://iopscience.iop.org/article/10.1088/0004-637X/737/2/103/pdf
-  coeff_extinc_u: 4.145
-  coeff_extinc_g: 3.237
-  coeff_extinc_r: 2.273
-  coeff_extinc_i: 1.684 
-  coeff_extinc_z: 1.323 
-  coeff_extinc_y: 1.088
+  # From rubin_sim (verions = 2.6.0, baseline version = 5.0.0)
+  # from rubin_sim.phot_utils import DustValues
+  # dust_values = DustValues()
+  # print(dust_values.r_x)
+  coeff_extinc_u: 4.757217815396922
+  coeff_extinc_g: 3.6605664439892625
+  coeff_extinc_r: 2.70136780871597
+  coeff_extinc_i: 2.0536599130965882
+  coeff_extinc_z: 1.5900964472616756
+  coeff_extinc_y: 1.3077049588254708
 
   # Systematic photometric errors (mag), or could be specified as sys_error_g, sys_error_r, etc
   sys_error : 0.005 # Error common to all bands

--- a/config/surveys/lsst_yr4.yaml
+++ b/config/surveys/lsst_yr4.yaml
@@ -11,8 +11,8 @@ survey_files:
 
     # Band-independent maps
     ebv_map: ebv_sfd98_lowres_nside_512_ring_equatorial.fits
-    completeness: stellar_efficiency_cutr.csv
-    log_photo_error: photoerror_r.csv
+    completeness: lsst_stellar_efficiency_cutr.csv
+    log_photo_error: lsst_photoerror_r.csv
 
 survey_properties: 
   bands: ['u', 'g', 'r', 'i', 'z', 'y']

--- a/config/surveys/lsst_yr4.yaml
+++ b/config/surveys/lsst_yr4.yaml
@@ -18,13 +18,16 @@ survey_properties:
   bands: ['u', 'g', 'r', 'i', 'z', 'y']
 
   # Extinction coefficients per band (A_band / E(B-V)) 
-  # from Tab 6 of https://iopscience.iop.org/article/10.1088/0004-637X/737/2/103/pdf
-  coeff_extinc_u: 4.145
-  coeff_extinc_g: 3.237
-  coeff_extinc_r: 2.273
-  coeff_extinc_i: 1.684 
-  coeff_extinc_z: 1.323 
-  coeff_extinc_y: 1.088
+  # From rubin_sim (verions = 2.6.0, baseline version = 5.0.0)
+  # from rubin_sim.phot_utils import DustValues
+  # dust_values = DustValues()
+  # print(dust_values.r_x)
+  coeff_extinc_u: 4.757217815396922
+  coeff_extinc_g: 3.6605664439892625
+  coeff_extinc_r: 2.70136780871597
+  coeff_extinc_i: 2.0536599130965882
+  coeff_extinc_z: 1.5900964472616756
+  coeff_extinc_y: 1.3077049588254708
 
   # Systematic photometric errors (mag), or could be specified as sys_error_g, sys_error_r, etc
   sys_error : 0.005 # Error common to all bands

--- a/config/surveys/lsst_yr4.yaml
+++ b/config/surveys/lsst_yr4.yaml
@@ -1,0 +1,36 @@
+# Configuration file for the survey LSST
+name: lsst
+release: yr4
+survey_files: 
+    # Path to data files (leave empty for default location)
+    file_path: ''
+
+    # Band-specific magnitude limit maps
+    maglim_map_g: baseline_v5.0.0_year_4.0_band_g_nside_128.hsp
+    maglim_map_r: baseline_v5.0.0_year_4.0_band_r_nside_128.hsp
+
+    # Band-independent maps
+    ebv_map: ebv_sfd98_lowres_nside_512_ring_equatorial.fits
+    completeness: stellar_efficiency_cutr.csv
+    log_photo_error: photoerror_r.csv
+
+survey_properties: 
+  bands: ['u', 'g', 'r', 'i', 'z', 'y']
+
+  # Extinction coefficients per band (A_band / E(B-V)) 
+  # from Tab 6 of https://iopscience.iop.org/article/10.1088/0004-637X/737/2/103/pdf
+  coeff_extinc_u: 4.145
+  coeff_extinc_g: 3.237
+  coeff_extinc_r: 2.273
+  coeff_extinc_i: 1.684 
+  coeff_extinc_z: 1.323 
+  coeff_extinc_y: 1.088
+
+  # Systematic photometric errors (mag), or could be specified as sys_error_g, sys_error_r, etc
+  sys_error : 0.005 # Error common to all bands
+  # sys_error_i: 0.01  # Example to Override for i-band
+
+
+  # Saturation limits per band, or could be specified as saturation_g, saturation_r, etc
+  saturation: 16.0
+  #saturation_u: 15.0  # Override for u-band

--- a/config/surveys/lsst_yr5.yaml
+++ b/config/surveys/lsst_yr5.yaml
@@ -18,13 +18,16 @@ survey_properties:
   bands: ['u', 'g', 'r', 'i', 'z', 'y']
 
   # Extinction coefficients per band (A_band / E(B-V)) 
-  # from Tab 6 of https://iopscience.iop.org/article/10.1088/0004-637X/737/2/103/pdf
-  coeff_extinc_u: 4.145
-  coeff_extinc_g: 3.237
-  coeff_extinc_r: 2.273
-  coeff_extinc_i: 1.684 
-  coeff_extinc_z: 1.323 
-  coeff_extinc_y: 1.088
+  # From rubin_sim (verions = 2.6.0, baseline version = 5.0.0)
+  # from rubin_sim.phot_utils import DustValues
+  # dust_values = DustValues()
+  # print(dust_values.r_x)
+  coeff_extinc_u: 4.757217815396922
+  coeff_extinc_g: 3.6605664439892625
+  coeff_extinc_r: 2.70136780871597
+  coeff_extinc_i: 2.0536599130965882
+  coeff_extinc_z: 1.5900964472616756
+  coeff_extinc_y: 1.3077049588254708
 
   # Systematic photometric errors (mag), or could be specified as sys_error_g, sys_error_r, etc
   sys_error : 0.005 # Error common to all bands

--- a/config/surveys/lsst_yr5.yaml
+++ b/config/surveys/lsst_yr5.yaml
@@ -11,8 +11,8 @@ survey_files:
 
     # Band-independent maps
     ebv_map: ebv_sfd98_lowres_nside_512_ring_equatorial.fits
-    completeness: stellar_efficiency_cutr.csv
-    log_photo_error: photoerror_r.csv
+    completeness: lsst_stellar_efficiency_cutr.csv
+    log_photo_error: lsst_photoerror_r.csv
 
 survey_properties: 
   bands: ['u', 'g', 'r', 'i', 'z', 'y']
@@ -36,4 +36,4 @@ survey_properties:
 
   # Saturation limits per band, or could be specified as saturation_g, saturation_r, etc
   saturation: 16.0
-  saturation_u: 15.0  # Override for u-band
+  #saturation_u: 15.0  # Override for u-band

--- a/docs/source/data.md
+++ b/docs/source/data.md
@@ -77,7 +77,7 @@ python bin/download_data.py --url https://custom-server.edu/data.zip
 #### Problem: Download fails with "404 Not Found"
 
 **Solution**: The data URL may have changed. Check the latest URL at:
-- Zenodo record: https://zenodo.org/records/17589908
+- Zenodo record: https://zenodo.org/records/17939098
 - Or update `BASE_DATA_URL` in `bin/download_data.py`
 
 #### Problem: Extraction fails
@@ -106,7 +106,7 @@ python bin/download_data.py --url https://custom-server.edu/data.zip
 The data files are hosted on [Zenodo](https://zenodo.org) with a persistent DOI for citation and long-term access.
 
 **DOI**: 10.5281/zenodo.17550956  
-**URL**: https://zenodo.org/records/17589908
+**URL**: https://zenodo.org/records/17939098
 **Version**: 1.0  
 **Last Updated**: November 2025
 
@@ -127,6 +127,9 @@ Each survey subdirectory contains magnitude limit maps (maglim maps) in HEALPix 
 
 Current surveys:
 - `lsst_yr1/` - LSST baseline v5.0.0, Year 1 observations (g, r bands)
+- `lsst_yr2/` - LSST baseline v5.0.0, Year 2 observations (g, r bands)
+- `lsst_yr3/` - LSST baseline v5.0.0, Year 3 observations (g, r bands)
+- `lsst_yr4/` - LSST baseline v5.0.0, Year 4 observations (g, r bands)
 - `lsst_yr5/` - LSST baseline v5.0.0, Year 5 observations (g, r bands)
 
 Additional surveys can be added by placing maglim maps in new subdirectories.
@@ -179,7 +182,7 @@ If you need to add or modify data files:
    ```
    
 2. **Upload to Zenodo**:
-   - Go to https://zenodo.org/records/17589908
+   - Go to https://zenodo.org/records/17939098
    - Create a new version
    - Upload the `data.zip` file
    - Add release notes describing changes

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -31,7 +31,7 @@ python bin/download_data.py --force         # Re-download/overwrite
 python bin/download_data.py --data-dir DIR  # Custom install location
 ```
 
-For troubleshooting and data structure, see [Citation](data.md).
+For troubleshooting and data structure, see [StreamSim Data Files](data.md).
 
 ## Dependences
 

--- a/stream_sim/observed.py
+++ b/stream_sim/observed.py
@@ -73,7 +73,7 @@ class StreamInjector:
             self.survey = survey
         else:
             raise ValueError("survey must be a string or Survey instance.")
-        
+
         # Instance attribute to store the last used gc_frame
         self._last_gc_frame = None
 
@@ -194,7 +194,9 @@ class StreamInjector:
             dust_correction = kwargs.get("dust_correction", True)
             if dust_correction:
                 if verbose:
-                    print(f"Applying dust correction for {band}-band on observed magnitudes.")
+                    print(
+                        f"Applying dust correction for {band}-band on observed magnitudes."
+                    )
                 # Correct observed magnitudes for extinction (only for valid detections)
                 valid_mask = mag_obs != "BAD_MAG"
                 # Create a float array for corrected magnitudes
@@ -219,7 +221,7 @@ class StreamInjector:
             data = pd.concat([data, new_columns], axis=1)
 
             # Compute detection flags for r-band (reference band)
-            if band == "r":                
+            if band == "r":
                 # Standard completeness (detection + classification)
                 flag_completeness_r = self.detect_flag(
                     pix_maglim,
@@ -245,9 +247,7 @@ class StreamInjector:
 
         # Validate that r-band was processed
         if flag_completeness_r is None:
-            raise ValueError(
-                "Detection flag requires 'r' band to be in bands list."
-            )
+            raise ValueError("Detection flag requires 'r' band to be in bands list.")
 
         # Build combined detection flags
         # Start with flux validity check (not BAD_MAG)
@@ -263,11 +263,13 @@ class StreamInjector:
         # Apply SNR cuts
         detection_mag_cut = kwargs.get("detection_mag_cut", ["g"])
         SNR_min = 5.0
-        
+
         for band in detection_mag_cut:
             if band not in bands:
                 if verbose:
-                    print(f"Warning: SNR cut requested for {band}-band but it's not in bands list. Skipping.")
+                    print(
+                        f"Warning: SNR cut requested for {band}-band but it's not in bands list. Skipping."
+                    )
                 continue
             if verbose:
                 print(f"Applying detection cut on {band}-band with SNR >= {SNR_min}")

--- a/stream_sim/observed.py
+++ b/stream_sim/observed.py
@@ -121,6 +121,8 @@ class StreamInjector:
         ValueError
             If required columns are missing or bands are not supported.
         """
+        verbose = kwargs.get("verbose", True)
+
         # Load data
         data = self._load_data(data)
 
@@ -134,6 +136,7 @@ class StreamInjector:
         # Get HEALPix pixel indices
         nside = kwargs.pop("nside", 4096)
         pix = hp.ang2pix(nside, data["ra"], data["dec"], lonlat=True)
+
 
         # Process each band
         for band in bands:
@@ -172,6 +175,13 @@ class StreamInjector:
                 seed=seed,
                 **kwargs,
             )
+
+            dust_correction = kwargs.get("dust_correction", True)
+            if dust_correction:
+                if verbose:
+                    print(f"Applying dust correction for {band}-band on observed magnitudes.")
+                # Correct observed magnitudes for extinction
+                mag_obs -= extinction_band
 
             # Add new columns
             new_columns = pd.DataFrame(
@@ -219,7 +229,8 @@ class StreamInjector:
         detection_mag_cut = kwargs.get("detection_mag_cut", ["g"])
         SNR_min = 5.0
         for band in detection_mag_cut:
-            print("Applying detection cut on", band, "band with SNR >=", SNR_min)
+            if verbose:
+                print("Applying detection cut on", band, "band with SNR >=", SNR_min)
             SNR = 1 / data["magerr_" + band]
             flag_observed &= SNR >= SNR_min
 

--- a/stream_sim/observed.py
+++ b/stream_sim/observed.py
@@ -180,8 +180,15 @@ class StreamInjector:
             if dust_correction:
                 if verbose:
                     print(f"Applying dust correction for {band}-band on observed magnitudes.")
-                # Correct observed magnitudes for extinction
-                mag_obs -= extinction_band
+                # Correct observed magnitudes for extinction (only for valid detections)
+                valid_mask = mag_obs != "BAD_MAG"
+                # Create a float array for corrected magnitudes
+                mag_obs_corrected = np.empty(len(mag_obs), dtype=object)
+                mag_obs_corrected[~valid_mask] = "BAD_MAG"
+                mag_obs_corrected[valid_mask] = (
+                    mag_obs[valid_mask].astype(float) - extinction_band[valid_mask]
+                )
+                mag_obs = mag_obs_corrected
 
             # Add new columns
             new_columns = pd.DataFrame(

--- a/stream_sim/plotting.py
+++ b/stream_sim/plotting.py
@@ -312,3 +312,32 @@ def plot_stream_in_mask(ra,dec,mask, nest=False, output_folder = None):
             plt.savefig(filename)
         
     return fig, ax
+
+
+def plot_healsparse_map(map):
+    if isinstance(map, np.ndarray): # healpix map
+        healpix_map = map
+    elif isinstance(map, str): # filename
+        healpix_map = hp.read_map(map, verbose=False)
+    elif 'healsparse' in globals():
+       import healsparse as hsp
+       if isinstance(map, hsp.HealSparseMap):
+           healsparse_map = map
+           nside_sparse = healsparse_map.nside_sparse 
+           nest = False  
+           healpix_map = healsparse_map.generate_healpix_map(nside=nside_sparse,nest=nest)
+    else:
+        raise ValueError("map must be a healpix map array, filename, or HealSparseMap object")
+         
+    fig, ax = plt.subplots(figsize=(8, 5))
+    sp = skyproj.McBrydeSkyproj(ax=ax)
+    sp.draw_hpxmap(healpix_map, nest=False)
+    plt.colorbar()   
+    fig.tight_layout()
+
+    return fig, ax
+
+
+def plot_maglim(maglim_map):
+    fig, ax = plot_healsparse_map(maglim_map)
+    return fig, ax

--- a/stream_sim/surveys.py
+++ b/stream_sim/surveys.py
@@ -26,7 +26,7 @@ class Survey:
     name : str
         Survey identifier (e.g., 'lsst').
     release : str, optional
-        Survey data release version (e.g., 'yr1', 'yr10').
+        Survey data release version (e.g., 'yr1', 'yr5').
     bands : list of str, optional
         List of photometric bands available (e.g., ['g', 'r', 'i']).
         Default is an empty list.
@@ -140,7 +140,7 @@ class Survey:
         survey : str
             Survey name (e.g., 'lsst').
         release : str, optional
-            Survey release/version (e.g., 'yr1', 'yr10').
+            Survey release/version (e.g., 'yr1', 'yr5').
         config_file : dict, optional
             Custom configuration dictionary.
         **kwargs
@@ -159,7 +159,7 @@ class Survey:
 
         Load with custom systematic error:
 
-        >>> survey = Survey.load('lsst', release='yr10', sys_error=0.01)
+        >>> survey = Survey.load('lsst', release='yr5', sys_error=0.01)
         """
         return SurveyFactory.create_survey(survey, release, config_file, **kwargs)
 
@@ -521,7 +521,7 @@ class SurveyFactory:
         survey : str
             Survey name (e.g., 'lsst').
         release : str, optional
-            Survey release/data version (e.g., 'yr1', 'yr10').
+            Survey release/data version (e.g., 'yr1', 'yr5').
             If None, loads the base survey configuration.
         config_file : dict, optional
             Custom configuration dictionary to use instead of loading from file.

--- a/stream_sim/surveys.py
+++ b/stream_sim/surveys.py
@@ -279,7 +279,7 @@ class Survey:
         )  # saturation at the bright end
 
         # Add band-specific systematic error in quadrature
-        sys_err = self.sys_error.get(band, 0.0)
+        sys_err = self.sys_error.get(band, 0.005)
         total_error = np.sqrt(mag_err_stat**2 + sys_err**2)
 
         return total_error

--- a/stream_sim/surveys.py
+++ b/stream_sim/surveys.py
@@ -859,6 +859,7 @@ class SurveyFactory:
                 ),
                 data_path_survey,
                 data_path_others,
+                filename=survey_config.get("completeness"), # use same file as completeness
             )
             except:
                 print("No detection efficiency file found, skipping.")
@@ -875,6 +876,7 @@ class SurveyFactory:
                 ),
                 data_path_survey,
                 data_path_others,
+                filename=survey_config.get("completeness"), # use same file as completeness
             )
             except:
                 print("No classification efficiency file found, skipping.")
@@ -972,6 +974,7 @@ class SurveyFactory:
         loader_func: Callable,
         data_path_survey: str,
         data_path_others: str = None,
+        filename: str = None,
     ):
         """
         Load a single data file and attach it to the survey object.
@@ -994,7 +997,8 @@ class SurveyFactory:
             Fallback directory for shared data files.
         """
         # Get filename from config
-        filename = config.get(attr_name)
+        if filename is None:
+            filename = config.get(attr_name)
 
         if filename is None:
             print(f"  ⚠ Warning: '{attr_name}' not specified in config (skipping)")
@@ -1093,7 +1097,7 @@ class SurveyFactory:
 
         # Select efficiency column based on user choice
         if selection == "detected":
-            efficiencies = data["eff_star"]
+            efficiencies = data["detection_eff"]
         elif selection == "classified":
             efficiencies = data["classifiction_eff"]
         elif selection == "both":


### PR DESCRIPTION

# Major updates/improvements

## Dust extinction
* Option to store dust corrected observed magnitudes, instead of observed magnitudes
* Update dust-extinction coefficients using rubin_sim values

## Others
* Option to study perfect star–galaxy separation
* Option to build homogeneous depth maps for a chosen release 
* Add support for new LSST releases (y2, y3, y4)


# Minor changes
- Stored the last Great Circle frame used. Can be useful when the user wants to re-inject at the same location in the sky, to add background, for example.
- Nan management in magnitude limit maps
- Added verbose option to survey classes
- Added plotting functions for healpix / healpsarse / magnitude limit maps
